### PR TITLE
Code that produces deprecation message in ember v2.x was fixed.

### DIFF
--- a/addon/initializers/events-bus.js
+++ b/addon/initializers/events-bus.js
@@ -1,4 +1,4 @@
-export function initialize(container, application) {
+export function initialize(application) {
   application.inject('route', 'eventsBus', 'service:events-bus');
   application.inject('route', 'globalEvents', 'service:events-bus');
   application.inject('component', 'eventsBus', 'service:events-bus');


### PR DESCRIPTION
Message:
`DEPRECATION: The `initialize` method for Application initializer 'events-bus' should take only one argument...` will no longer be shown.
